### PR TITLE
fetching contacts in new thread (Android)

### DIFF
--- a/android/src/main/java/com/wix/pagedcontacts/PagedContactsModule.java
+++ b/android/src/main/java/com/wix/pagedcontacts/PagedContactsModule.java
@@ -68,10 +68,19 @@ public class PagedContactsModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getContactsWithRange(String uuid, int offset, int size, ReadableArray keysToFetch, Promise promise) {
-        QueryParams params = new QueryParams(Collections.toStringList(keysToFetch), offset, size);
-        WritableArray contacts = contactProvider.get(uuid).getContacts(params);
-        promise.resolve(contacts);
+    public void getContactsWithRange(final String uuid, final int offset, final int size, final ReadableArray keysToFetch, final Promise promise) {
+        final Thread t = new Thread(new Runnable() {
+            public void run() {
+                try {
+                    QueryParams params = new QueryParams(Collections.toStringList(keysToFetch), offset, size);
+                    WritableArray contacts = contactProvider.get(uuid).getContacts(params);
+                    promise.resolve(contacts);
+                } catch (Exception e) {
+
+                }
+            }
+        });
+        t.start();
     }
 
     @ReactMethod


### PR DESCRIPTION
**description:**
added a new thread for fetching contacts on Android, because it takes some time and makes the main thread irresponsible for user interactions

**the reason for this PR:**
I have ~350 contacts and it takes 5-7 seconds to fetch it with few keys (displayName, givenName, thumbnailImageData, phoneNumbers, instantMessageAddresses). 

**Alternative proposition:**
As I understood, the main time eater is thumbnailImageData. So maybe it will be faster if to give links to the thumbnail in this look "content://com.android.contacts/contacts/527/photo"? (add new key 'thumbnailUri')