### PR TITLE
Fix fetching contact no phone no email on Android

### DIFF
--- a/android/src/main/java/com/wix/pagedcontacts/contacts/query/Selection.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/query/Selection.java
@@ -34,7 +34,7 @@ class Selection {
         }
         if (!TextUtils.isEmpty(contactSelection)) {
             if (!TextUtils.isEmpty(mimeTypeSelection)) {
-                result = "(" + result + ") AND (" + contactSelection + ")";
+                result = "(" + result + ") OR (" + contactSelection + ")";
             } else {
                 result = contactSelection;
             }


### PR DESCRIPTION
On Android, contacts with no email and with no phone are not fetched, while such contacts are fetched on iOS.