### PR TITLE
Android - change min SDK version and return contact's lookup key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Paged contacts manager for React Native.
 #### Available Keys to Fetch
 
 - `PagedContacts.identifier` — The contact’s unique identifier.
+- `PagedContacts.lookupKey` — The contact’s lookup key. (**Android only**)
 - `PagedContacts.displayName`
 - `PagedContacts.namePrefix` — Name prefix.
 - `PagedContacts.givenName` — Given name.
@@ -189,6 +190,7 @@ This is a very intensive way of obtaining specific keys of all contacts. Instead
     }
   ],
   "identifier": "60CB0169-0747-4494-9F10-22F387226676",
+  "lookupKey": "0r5-3535352929291A1A142F14141624",
   "urlAddresses": [
     {
       "label": "homepage",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"

--- a/android/src/main/java/com/wix/pagedcontacts/contacts/ContactsProvider.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/ContactsProvider.java
@@ -33,7 +33,7 @@ public class ContactsProvider {
     }
 
     public int getContactsCount() {
-        ensureContactIds();
+        sync();
         return contactIds.size();
     }
 
@@ -64,7 +64,7 @@ public class ContactsProvider {
     }
 
     private WritableArray getContactsWithNameFilter(QueryParams params) {
-        ensureContactIds();
+        sync();
         int size = contactIds.size();
         int offset = 0;
         List<List<Contact>> contactLists = new ArrayList<>();
@@ -81,7 +81,7 @@ public class ContactsProvider {
     }
 
     private List<Contact> getContactsWithRange(QueryParams params) {
-        ensureContactIds();
+        sync();
         List<String> contactsToFetch = getContactsToFetch(params);
         if (contactsToFetch.isEmpty()) {
             return Collections.emptyList();
@@ -92,7 +92,7 @@ public class ContactsProvider {
     }
 
     public WritableArray getContactsWithIdentifiers(QueryParams params) {
-        ensureContactIds();
+        sync();
         params.setContactsToFetch(getContactsToFetch(params));
         Cursor cursor = queryContacts(params);
         List<Contact> contacts = new ContactCursorReader(context).readWithIds(cursor);
@@ -107,12 +107,6 @@ public class ContactsProvider {
             }
         }
         return result;
-    }
-
-    private void ensureContactIds() {
-        if (contactIds.isEmpty()) {
-            sync();
-        }
     }
 
     private void sync() {

--- a/android/src/main/java/com/wix/pagedcontacts/contacts/Field.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/Field.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 public enum Field {
     identifier("identifier", new String[]{}),
+    lookupKey("lookupKey", new String[]{}),
     displayName("displayName", new String[]{ContactsContract.Contacts.DISPLAY_NAME}),
     identity("identity", Identity.CONTENT_ITEM_TYPE, new String[]{Identity.IDENTITY, Identity.NAMESPACE}),
     namePrefix("namePrefix", StructuredName.CONTENT_ITEM_TYPE, new String[]{StructuredName.PREFIX}),

--- a/android/src/main/java/com/wix/pagedcontacts/contacts/Items/Contact.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/Items/Contact.java
@@ -31,8 +31,8 @@ public class Contact {
     public List<UrlAddress> urlAddresses = new ArrayList<>();
     public Photo photo = new Photo();
 
-    public Contact(String contactId) {
-        this.identifier = new Identifier(contactId);
+    public Contact(String contactId, String lookupKey) {
+        this.identifier = new Identifier(contactId, lookupKey);
     }
 
     public WritableMap toMap(QueryParams params) {

--- a/android/src/main/java/com/wix/pagedcontacts/contacts/Items/ContactItemReader.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/Items/ContactItemReader.java
@@ -57,9 +57,16 @@ public class ContactItemReader {
             case ContactsContract.CommonDataKinds.Identity.CONTENT_ITEM_TYPE:
                 readIdentity(cursor);
                 break;
+            case ContactsContract.CommonDataKinds.Identity.LOOKUP_KEY:
+                readLookupKey(cursor);
+                break;
             default:
                 break;
         }
+    }
+
+    private void readLookupKey(Cursor cursor) {
+        contact.identifier.lookupKey = cursor.getString(cursor.getColumnIndex(ContactsContract.Data.LOOKUP_KEY));
     }
 
     private void readIdentity(Cursor cursor) {

--- a/android/src/main/java/com/wix/pagedcontacts/contacts/Items/Identifier.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/Items/Identifier.java
@@ -6,13 +6,16 @@ import com.wix.pagedcontacts.contacts.query.QueryParams;
 
 class Identifier extends ContactItem {
     String contactId;
+    String lookupKey;
 
-    Identifier(String contactId) {
+    Identifier(String contactId, String lookupKey) {
         this.contactId = contactId;
+        this.lookupKey = lookupKey;
     }
 
     @Override
     protected void fillMap(WritableMap map, QueryParams params) {
         addToMap(map, Field.identifier.getKey(), contactId);
+        addToMap(map, Field.lookupKey.getKey(), lookupKey);
     }
 }

--- a/android/src/main/java/com/wix/pagedcontacts/contacts/query/QueryParams.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/query/QueryParams.java
@@ -68,6 +68,7 @@ public class QueryParams {
             }
         }
         projection.add(ContactsContract.Data.CONTACT_ID);
+        projection.add(ContactsContract.Data.LOOKUP_KEY);
         return projection.toArray(new String[projection.size()]);
     }
 

--- a/android/src/main/java/com/wix/pagedcontacts/contacts/readers/ContactCursorReader.java
+++ b/android/src/main/java/com/wix/pagedcontacts/contacts/readers/ContactCursorReader.java
@@ -27,7 +27,7 @@ public class ContactCursorReader {
     }
 
     public Contact read(Cursor cursor) {
-        Contact contact = new Contact(getId(cursor));
+        Contact contact = new Contact(getId(cursor), getLookupKey(cursor));
         contact.identity = new Identity(cursor);
         contact.displayName = new DisplayName(cursor);
         return contact;
@@ -37,7 +37,7 @@ public class ContactCursorReader {
         Set<String> fetchedContacts = new HashSet<>();
         List<Contact> contacts = new ArrayList<>();
         while (cursor.moveToNext()) {
-            Contact contact = read(cursor, getId(cursor));
+            Contact contact = read(cursor, getId(cursor), getLookupKey(cursor));
             if (!fetchedContacts.contains(contact.getContactId())) {
                 fetchedContacts.add(contact.getContactId());
                 contacts.add(contact);
@@ -46,8 +46,8 @@ public class ContactCursorReader {
         return contacts;
     }
 
-    private Contact read(Cursor cursor, String contactId) {
-        Contact contact = getContact(contactId);
+    private Contact read(Cursor cursor, String contactId, String lookupKey) {
+        Contact contact = getContact(contactId, lookupKey);
         contact.displayName = new DisplayName(cursor);
         readField(cursor, contact);
         return contact;
@@ -61,10 +61,10 @@ public class ContactCursorReader {
         }
     }
 
-    private Contact getContact(String contactId) {
+    private Contact getContact(String contactId, String lookupKey) {
         Contact contact = contacts.get(contactId);
         if (contact == null) {
-            contact = new Contact(contactId);
+            contact = new Contact(contactId, lookupKey);
             contacts.put(contactId, contact);
         }
         return contact;
@@ -72,5 +72,9 @@ public class ContactCursorReader {
 
     private String getId(Cursor cursor) {
         return String.valueOf(cursor.getInt(cursor.getColumnIndex(ContactsContract.Data.CONTACT_ID)));
+    }
+
+    private String getLookupKey(Cursor cursor) {
+        return cursor.getString(cursor.getColumnIndex(ContactsContract.Data.LOOKUP_KEY));
     }
 }

--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ if (Platform.OS === 'ios') {
 }
 if (Platform.OS === 'android') {
   PagedContacts.identity = PagedContactsModule.identity;
+  PagedContacts.lookupKey = PagedContactsModule.lookupKey;
 }
 
 PagedContacts.denied = PagedContactsModule.denied;


### PR DESCRIPTION
Changes for Android only.

1. Min SDK version doesn't need to be that high. You don't use any API which requires Android 5.0
2. Added LOOKUP_KEY (https://developer.android.com/reference/android/provider/ContactsContract.ContactsColumns.html#LOOKUP_KEY) which can be used to start new intent to open contact details like here (https://developer.android.com/training/contacts-provider/modify-data.html)